### PR TITLE
Some fixes after reflashing quintana

### DIFF
--- a/pirania/files/etc/config/pirania
+++ b/pirania/files/etc/config/pirania
@@ -1,6 +1,6 @@
 config base_config 'base_config'
     option enabled '0'
-    option portal_url 'http://thisnode.info/portal'
+    option portal_url 'http://thisnode.info/portal/'
     option db_path '/etc/pirania/db.csv'
     option hooks_path '/etc/pirania/hooks/'
     option uploadlimit '10000000'

--- a/pirania/files/etc/init.d/pirania
+++ b/pirania/files/etc/init.d/pirania
@@ -17,5 +17,5 @@ start() {
 stop () {
     /usr/lib/lua/voucher/hooks.lua stop
     $PROG stop
-    logger -t pirania "Portal captive - to be implemented"
+    logger -t pirania "Portal captive stopped"
 }

--- a/pirania/files/usr/bin/captive-portal
+++ b/pirania/files/usr/bin/captive-portal
@@ -81,6 +81,7 @@ set_iptables () {
 }
 
 set_ipsets () {
+	ipset -exist create pirania-auth-macs hash:mac timeout 0
 	for mac in $(voucher print_valid_macs) ; do
 		ipset -exist add pirania-auth-macs $mac
 	done


### PR DESCRIPTION
When I ran captive-portal I noticed some errors, I detected them because the redirect was in a loop and the terminal commands didn't seem to respond.
The bugs were incorporated in the last commit, where the code was reorganized.